### PR TITLE
Add dropdown options for each calendar

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -3254,19 +3254,27 @@ $("#rcmfd_new_category").keypress(function(event) {
 
         // add "Save to calendar" button into attachment menu
         if ($has_events) {
-            $this->add_button([
-                    'id'         => 'attachmentsavecal',
-                    'name'       => 'attachmentsavecal',
-                    'type'       => 'link',
-                    'wrapper'    => 'li',
-                    'command'    => 'attachment-save-calendar',
-                    'class'      => 'icon calendarlink disabled',
-                    'classact'   => 'icon calendarlink active',
+            $calendars = $this->driver->list_calendars(calendar_driver::FILTER_PERSONAL | calendar_driver::FILTER_WRITEABLE);
+
+            foreach($calendars as $calendar) {
+                //TODO inline style tags are a bit ugly, but I cant think of a better way of coloring the icon
+                $style = html::tag('style', ['type' => 'text/css'], ".icon.cal-$calendar[id]::before {color: #$calendar[color]}");
+                $this->add_button([
+                    'id' => 'attachmentsavecal-' .$calendar['id'],
+                    'name' => 'attachmentsavecal',
+                    'type' => 'link',
+                    'wrapper' => 'li',
+                    'command' => 'attachment-save-calendar',
+                    'prop' => $calendar['id'],
+                    'class' => 'icon calendarlink disabled',
+                    'classact' => "icon calendarlink active cal-$calendar[id]",
                     'innerclass' => 'icon calendar',
-                    'label'      => 'calendar.savetocalendar',
+                    //maybe change the calendar.savetocalendar translation so a calendar can be added and use a label instead?
+                    'content' => $this->gettext('calendar.savetocalendar') ." ($calendar[name]) $style"
                 ],
-                'attachmentmenu'
-            );
+                    'attachmentmenu'
+                );
+            }
         }
 
         return $p;

--- a/calendar_base.js
+++ b/calendar_base.js
@@ -72,13 +72,12 @@ function rcube_calendar(settings)
     // handler for attachment-save-calendar commands
     this.save_to_calendar = function(p)
     {
-      // TODO: show dialog to select the calendar for importing
       if (this.selected_attachment && window.rcube_libcalendaring) {
         rcmail.http_post('calendar/mailimportattach', {
             _uid: rcmail.env.uid,
             _mbox: rcmail.env.mailbox,
-            _part: this.selected_attachment
-            // _calendar: $('#calendar-attachment-saveto').val(),
+            _part: this.selected_attachment,
+            _calendar: p
           }, rcmail.set_busy(true, 'itip.savingdata'));
       }
     };
@@ -93,7 +92,7 @@ window.rcmail && rcmail.addEventListener('init', function(evt) {
     // register create-from-mail command to message_commands array
     if (rcmail.env.task == 'mail') {
       rcmail.register_command('calendar-create-from-mail', function() { cal.create_from_mail(); });
-      rcmail.register_command('attachment-save-calendar', function() { cal.save_to_calendar(); });
+      rcmail.register_command('attachment-save-calendar', function(p) { cal.save_to_calendar(p); });
 
       if (rcmail.env.action != 'show') {
         rcmail.env.message_commands.push('calendar-create-from-mail');


### PR DESCRIPTION
At the moment, the user can not choose to which calendar an ics-file attached to an email should be added to.
This addition adds import options for each calendar in the dropdown menu.